### PR TITLE
fix: 時間のずれを対処

### DIFF
--- a/backend/src/post/post.service.ts
+++ b/backend/src/post/post.service.ts
@@ -74,7 +74,7 @@ export class PostService {
         'micro_post.created_at as created_at',
       ])
       // SQL: ORDER BY micro_post.created_at DESC
-      .orderBy('micro_post.created_At', 'DESC')
+      .orderBy('micro_post.created_at', 'DESC')
 
       // オフセット（ページネーション用）
       // SQL: OFFSET 10 (例)
@@ -93,6 +93,9 @@ export class PostService {
     };
     const records = await qb.getRawMany<ResultType>();
 
-    return records;
+    return records.map((record) => ({
+      ...record,
+      created_at: record.created_at.toISOString(),
+    }));
   }
 }

--- a/frontend/src/components/Post.tsx
+++ b/frontend/src/components/Post.tsx
@@ -4,9 +4,10 @@ import styled from "styled-components";
 
 // (学習メモ): propsはオブジェクトになるので、左側に分割代入
 const Post = ({ post }: { post: PostType }) => {
+  // FIX: localhostだとUTCになってrenderだとJTCになるっぽい？
   // NOTE: サーバーがZをつけて、UTCであるという指定をしていないので、ここでつける 
-  const dateString = `${post.created_at}Z`;
-  const date = new Date(dateString);
+  const dateString = post.created_at.toString().endsWith('Z') ? post.created_at : `${post.created_at.toString().replace(' ', 'T')}Z`;
+  const date = new Date(post.created_at);
   const getDateString = (dateObj: Date) => {
     return dateObj.toLocaleString();
   };


### PR DESCRIPTION
## 関連するIssue

fixes #39

## 変更内容

- nestJS側でcreated_atをtoISOStringして返す
- フロントエンドでZをつける処理をやめてみる

## 動作確認

- [ ] localhostではUTCにずれたまま
- [ ] render.comで正しく動作するか確認の必要があり

## 影響範囲

## スクリーンショット / 動画
